### PR TITLE
ARROW-2841: [Go] support building in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -219,6 +219,7 @@ matrix:
     - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   # Go
   - language: go
+    go_import_path: github.com/apache/arrow
     os: linux
     go:
     - 1.10.x


### PR DESCRIPTION
Go is pretty adamant about where source code needs to be.
A package named "github.com/apache/arrow/go" needs to be checked out
under $GOPATH/src/github.com/apache/arrow/go, otherwise wires get
crossed.

Fortunately, Travis-CI has some support to allow checking out a repository
 github.com/foo/bar
under
 example.com/foo/bar
(this is for the so-called "vanity imports.")
Reuse this facility for the forks.